### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the **GitHub Skills** activity to the school's extracurricular activities system.

## Issue

Closes #6 — The principal announced a new partnership with GitHub to teach students practical coding and collaboration skills. Students were unable to find and register for this activity on the website.

## Changes

- Added "GitHub Skills" to the activities dictionary in `src/app.py`
  - **Description:** Learn practical coding and collaboration skills using GitHub, part of the GitHub Certifications program
  - **Schedule:** Mondays and Wednesdays, 3:30 PM - 4:30 PM
  - **Max participants:** 25
  - **Participants:** Starts empty, ready for registrations

## Testing

- Activity appears in the `/activities` API endpoint
- Students can sign up via the existing signup flow
- No scheduling conflicts with other activities